### PR TITLE
Save PEMS in a simplified data format

### DIFF
--- a/notebooks/GeometricProbabilisticModels.ipynb
+++ b/notebooks/GeometricProbabilisticModels.ipynb
@@ -49,6 +49,8 @@
    ],
    "source": [
     "# Basic Imports\n",
+    "import os\n",
+    "from pathlib import Path\n",
     "import random\n",
     "import numpy as np\n",
     "import torch\n",
@@ -109,7 +111,7 @@
     ")\n",
     "\n",
     "# Utils\n",
-    "from pems_regression.utils import dcn"
+    "from pems_regression.utils import dcn, extract_node_coordinates"
    ]
   },
   {
@@ -331,6 +333,59 @@
     "    train_mask=train_mask,\n",
     "    test_mask=test_mask,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REGEN_SIMPLIFIED_TORCH_FILES = False\n",
+    "\n",
+    "if REGEN_SIMPLIFIED_TORCH_FILES:\n",
+    "    base_resource_dir = Path(os.getcwd()).parent / \"pems_regression\" / \"resources\"\n",
+    "\n",
+    "    simplified_torch_save_path = base_resource_dir / \"simplified_torch_version\"\n",
+    "    simplified_torch_save_path.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    # Save geographical positions of nodes\n",
+    "    extract_node_coordinates(nx_graph, simplified_torch_save_path / \"node_coordinates.pt\")\n",
+    "\n",
+    "    ################################################################################################ \n",
+    "\n",
+    "    # Save information for valid labels and splits\n",
+    "    np.savez_compressed(simplified_torch_save_path / \"valid_label_index_data.npz\", *data)\n",
+    "\n",
+    "    # Sanity check on save data\n",
+    "    loaded_data = np.load(simplified_torch_save_path / \"valid_label_index_data.npz\")\n",
+    "    _data = tuple(loaded_data[f\"arr_{i}\"] for i in range(len(loaded_data.files)))\n",
+    "\n",
+    "    data_structure =  type(data) == type(_data)\n",
+    "    data_dtype = data[0].dtype == _data[0].dtype\n",
+    "    data_zero = np.all(np.equal(data[0], _data[0]))\n",
+    "    data_one = np.all(np.equal(data[1], _data[1]))\n",
+    "    assert data_structure and data_dtype and data_zero and data_one\n",
+    "\n",
+    "    ################################################################################################ \n",
+    "\n",
+    "    torch.save(pyg_data.edge_index, simplified_torch_save_path / \"edge_index.pt\")\n",
+    "    loaded_edge_index = torch.load(simplified_torch_save_path / \"edge_index.pt\")\n",
+    "\n",
+    "    structure_match_edge_index = pyg_data.edge_index.shape == loaded_edge_index.shape\n",
+    "    data_type_match_edge_index = pyg_data.edge_index.dtype == loaded_edge_index.dtype\n",
+    "    data_match_loaded_edge_index = pyg_data.edge_index.equal(loaded_edge_index)\n",
+    "    assert structure_match_edge_index and data_type_match_edge_index and data_match_loaded_edge_index\n",
+    "\n",
+    "    ################################################################################################ \n",
+    "\n",
+    "    torch.save(pyg_data.edge_weight, simplified_torch_save_path / \"edge_features.pt\")\n",
+    "    loaded_edge_weight = torch.load(simplified_torch_save_path / \"edge_features.pt\")\n",
+    "\n",
+    "    structure_match_edge_weight = pyg_data.edge_weight.shape == loaded_edge_weight.shape\n",
+    "    data_type_match_edge_weight = pyg_data.edge_weight.dtype == loaded_edge_weight.dtype\n",
+    "    data_match_loaded_edge_weight = pyg_data.edge_weight.equal(loaded_edge_weight)\n",
+    "    assert structure_match_edge_weight and data_type_match_edge_weight and data_match_loaded_edge_weight"
    ]
   },
   {

--- a/pems_regression/utils.py
+++ b/pems_regression/utils.py
@@ -1,2 +1,29 @@
+import torch
+
 def dcn(x):
     return x.detach().cpu().numpy()
+
+
+def extract_node_coordinates(G, save_path="node_coordinates.pt"):
+    """
+    Extract node coordinates from an OSMnx graph into an (N, 2) torch tensor,
+    ordered by ascending node ID.
+
+    Args:
+        G: OSMnx graph object with node attributes "x" (longitude) and "y" (latitude)
+        save_path: path to save the tensor (default: "node_coordinates.pt")
+
+    Returns:
+        coords: (N, 2) float tensor, columns are [longitude, latitude],
+                rows ordered by ascending node ID
+    """
+    sorted_nodes = sorted(G.nodes)
+
+    coords = torch.tensor(
+        [[G.nodes[n]["x"], G.nodes[n]["y"]] for n in sorted_nodes],
+        dtype=torch.float64,
+    )  # shape (N, 2): [:, 0] = longitude, [:, 1] = latitude
+
+    torch.save(coords, save_path)
+    print(f"Saved coordinate tensor of shape {coords.shape} to '{save_path}'")
+


### PR DESCRIPTION
Process to save PeMS in a simplified data format (torch and numpy based compressed formats). This allows a straightforward way of replicating how the data is organised in the existing [Zenodo repository](https://doi.org/10.5281/zenodo.20394853). It shouldn't hinder the execution of the notebook due to the "if guard". It is convenient for this process to be in the notebook so that it is clear that the data stems from the source that is later used in model training.  